### PR TITLE
Enable click handler on polybar workspaces

### DIFF
--- a/.config/polybar/config
+++ b/.config/polybar/config
@@ -76,7 +76,7 @@ pin-workspaces = true
 
 ; Create click handler used to focus desktop
 ; Default: true
-enable-click = false
+enable-click = true
 
 ; Create scroll handlers used to cycle desktops
 ; Default: true


### PR DESCRIPTION
User should now be able to click on workspace icons on polybar to switch them